### PR TITLE
use wrappedJSObject wrapper for firefox

### DIFF
--- a/src/Frame.jsx
+++ b/src/Frame.jsx
@@ -98,7 +98,11 @@ export default class Frame extends Component {
     );
 
     if (doc.body.children.length < 1) {
-      doc.open('text/html', 'replace');
+      if (doc.wrappedJSObject) {
+        doc.wrappedJSObject.open('text/html', 'replace');
+      } else {
+        doc.open('text/html', 'replace');
+      }
       doc.write(this.props.initialContent);
       doc.close();
     }


### PR DESCRIPTION
Currently, when we go to open the the document, Firefox will throw an error saying: 
`DOMException: "The operation is insecure."`

Firefox wants us to use the wrappedJSObject to access this property from content script. 
https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/Sharing_objects_with_page_scripts